### PR TITLE
Support huge amount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 csv = "1.1"
 num-traits = "0.2"
 rust_decimal = "1.26"
-serde = "1"
+serde = { version = "1", features = ["derive"] }

--- a/sample.csv
+++ b/sample.csv
@@ -8,3 +8,4 @@ dispute, 1, 1,
 resolve, 1,  1     ,  
 dispute, 1, 1,
 chargeback, 1,1,
+deposit, 3, 6, 1237940039285380274899124224.1234

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1,7 +1,6 @@
 use crate::*;
 use std::collections::HashMap;
 
-// There is no assumption on the limit of amount.
 type DiffAmount = rust_decimal::Decimal;
 
 // Deposite and Withdrawal are different only by the sign.
@@ -88,7 +87,6 @@ impl TxCompute {
         }
         match command {
             TxCommand::Deposit { tx, amount } => {
-                let amount = amount.try_into().unwrap();
                 // eff = effect
                 // I name this because it is an effect to the balance.
                 let eff = ChangeDeposit {
@@ -101,7 +99,6 @@ impl TxCompute {
                 self.changes.insert(tx, eff);
             }
             TxCommand::Withdrawal { tx, amount } => {
-                let amount: DiffAmount = amount.try_into().unwrap();
                 let eff = ChangeDeposit {
                     add_available: -amount,
                     add_total: -amount,
@@ -166,9 +163,14 @@ impl TxCompute {
 
 #[cfg(test)]
 mod tests {
+    use crate::Amount;
     use crate::TxCommand::*;
 
     use super::DiffAmount;
+    fn amount(x: f32) -> Amount {
+        let amount: DiffAmount = x.try_into().unwrap();
+        amount
+    }
     fn to_f32(x: DiffAmount) -> f32 {
         use num_traits::cast::ToPrimitive;
         x.to_f32().unwrap()
@@ -189,8 +191,14 @@ mod tests {
     fn test_normal() {
         assert_eq!(
             run([
-                Deposit { tx: 1, amount: 3.0 },
-                Withdrawal { tx: 2, amount: 2.0 },
+                Deposit {
+                    tx: 1,
+                    amount: amount(3.0)
+                },
+                Withdrawal {
+                    tx: 2,
+                    amount: amount(2.0)
+                },
             ]),
             (1., 0., 1.)
         );
@@ -199,8 +207,14 @@ mod tests {
     fn test_mal_withdrawal() {
         assert_eq!(
             run([
-                Deposit { tx: 1, amount: 3.0 },
-                Withdrawal { tx: 2, amount: 4.0 },
+                Deposit {
+                    tx: 1,
+                    amount: amount(3.0)
+                },
+                Withdrawal {
+                    tx: 2,
+                    amount: amount(4.0)
+                },
             ]),
             (3., 0., 3.)
         );
@@ -209,8 +223,14 @@ mod tests {
     fn test_mal_dispute() {
         assert_eq!(
             run([
-                Deposit { tx: 1, amount: 3.0 },
-                Withdrawal { tx: 2, amount: 2.0 },
+                Deposit {
+                    tx: 1,
+                    amount: amount(3.0)
+                },
+                Withdrawal {
+                    tx: 2,
+                    amount: amount(2.0)
+                },
                 // This dispute should be denied.
                 Dispute { tx: 1 },
             ]),
@@ -221,8 +241,14 @@ mod tests {
     fn test_normal_dispute() {
         assert_eq!(
             run([
-                Deposit { tx: 1, amount: 3.0 },
-                Withdrawal { tx: 2, amount: 2.0 },
+                Deposit {
+                    tx: 1,
+                    amount: amount(3.0)
+                },
+                Withdrawal {
+                    tx: 2,
+                    amount: amount(2.0)
+                },
                 Dispute { tx: 2 },
             ]),
             (3., -2., 1.)
@@ -232,8 +258,14 @@ mod tests {
     fn test_resolve() {
         assert_eq!(
             run([
-                Deposit { tx: 1, amount: 3.0 },
-                Withdrawal { tx: 2, amount: 2.0 },
+                Deposit {
+                    tx: 1,
+                    amount: amount(3.0)
+                },
+                Withdrawal {
+                    tx: 2,
+                    amount: amount(2.0)
+                },
                 Dispute { tx: 2 },
                 Resolve { tx: 2 },
             ]),
@@ -244,8 +276,14 @@ mod tests {
     fn test_chargeback() {
         assert_eq!(
             run([
-                Deposit { tx: 1, amount: 3.0 },
-                Withdrawal { tx: 2, amount: 2.0 },
+                Deposit {
+                    tx: 1,
+                    amount: amount(3.0)
+                },
+                Withdrawal {
+                    tx: 2,
+                    amount: amount(2.0)
+                },
                 Dispute { tx: 2 },
                 Chargeback { tx: 2 },
             ]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,15 @@ use std::collections::HashMap;
 mod compute;
 mod reader;
 
+// Non-negative amount.
+type Amount = rust_decimal::Decimal;
 type ClientId = u16;
 type TxId = u32;
 
 #[derive(Debug)]
 pub enum TxCommand {
-    Deposit { tx: TxId, amount: f32 },
-    Withdrawal { tx: TxId, amount: f32 },
+    Deposit { tx: TxId, amount: Amount },
+    Withdrawal { tx: TxId, amount: Amount },
     Dispute { tx: TxId },
     // Retract dispute.
     Resolve { tx: TxId },

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -53,6 +53,6 @@ mod tests {
             rows.push(row.unwrap());
         }
         dbg!(&rows);
-        assert_eq!(rows.len(), 9);
+        assert_eq!(rows.len(), 10);
     }
 }


### PR DESCRIPTION
Since the current parser uses f32 as the amount and it lacks lot of precision in case of huge amount. The test case is 1237940039285380274899124224.1234

```
    Tx {
        client_id: 3,
        command: Deposit {
            tx: 6,
            amount: 1.2379401e27, // like this
        },
    },
```

This fix is to use rust_decimal::Decimal in parsing as well. It got better but still lacks precision.

```
    Tx {
        client_id: 3,
        command: Deposit {
            tx: 6,
            amount: 1237940039285380300000000000, // still no good
        },
    },
```

Strangely, deserializing with serde differs in precision from naive `from_str`

```rust
 let x = "1237940039285380274899124224.1234";
// 1237940039285380274899124224.1
rust_decimal::Decimal::from_str(x).unwrap()
```